### PR TITLE
Content-Type header is required for v5 of the API

### DIFF
--- a/lib/xbmc-client.rb
+++ b/lib/xbmc-client.rb
@@ -25,7 +25,9 @@ class Xbmc
     # Raw API interaction: Invoke the given JSON RPC Api call and return the raw response (which is an instance of
     # HTTParty::Response)
     def invoke_method(method, params={})
-      response = post('/jsonrpc', :body => {"jsonrpc" => "2.0", "params" => params, "id" => "1", "method" => method}.to_json)
+      response = post('/jsonrpc',
+                      :body => {"jsonrpc" => "2.0", "params" => params, "id" => "1", "method" => method}.to_json,
+                      :headers => {'Content-Type' => 'application/json'})
       raise Xbmc::UnauthorizedError, "Could not authorize with XBMC. Did you set up your credentials for basic_auth using Xbmc.basic_auth 'user', 'pass'?" if response.response.class == Net::HTTPUnauthorized
       response
       


### PR DESCRIPTION
From http://wiki.xbmc.org/index.php?title=JSON-RPC_API

FUTURE FRODO FEATURE:
Starting with Frodo nightly builds it is mandatory to set the HTTP header field Content-Type: application/json
