### PR TITLE
Remove bundler and rubygems dependency

### DIFF
--- a/lib/xbmc-client.rb
+++ b/lib/xbmc-client.rb
@@ -1,8 +1,3 @@
-require 'rubygems'
-require 'bundler'
-
-Bundler.require(:default)
-
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'httparty'
 require 'ruby_ext'


### PR DESCRIPTION
The gem should not depend on rubygems or bundler.

Removing these dependencies allows it to be built and installed as follows:

```
gem build xbmc-client.gemspec
gem install xbmc-client-0.1.2.gem
```

Then require 'xbmc-client' works no matter what the current working directory is.
